### PR TITLE
Update README to decommission

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # AK Unpause
 
+**Current Status: As of August 2022, this script is decommissioned. All deployments have been deleted.**
+
 This is a small Python 3.6 script that runs a query and imports the resulting user IDs into ActionKit. The query finds people who have been on our "pause" list for 30 days and the import page removes them from that list, so it "un-pauses" members after 30 days.
 
 Both the query and the import page are configurable, so this could be easily repurposed.


### PR DESCRIPTION
We have Product's permission to decommission this script. The deployment has been deleted, and this change is just a simple update to the README to make it clear this isn't running anywhere.